### PR TITLE
Refs #296: remove label for _user_ from the user profile page

### DIFF
--- a/templates/user/view.tpl
+++ b/templates/user/view.tpl
@@ -42,7 +42,7 @@
 
       <div class="col-12 col-md-9 mt-2">
         <h1 class="fw-bold mb-5 center-mobile">
-          {t}label-user{/t} {$user}
+          {$user}
         </h1>
 
         <dl class="row">


### PR DESCRIPTION
Instead of 'User sonia' as the page name (heading), we now have just 'Sonia'